### PR TITLE
fixed certificate name typo 'tls-selfsigned-ca'

### DIFF
--- a/deploy-k3s.sh
+++ b/deploy-k3s.sh
@@ -399,7 +399,7 @@
   print_title
   
   kubectl wait --for=condition=Ready clusterissuers.cert-manager.io selfsigned-ca-issuer --timeout=${TIMEOUT}s
-  kubectl --namespace cert-manager wait --for=condition=Ready certificates.cert-manager.io tls-selfsigned-ca --timeout=${TIMEOUT}s
+  kubectl --namespace cert-manager wait --for=condition=Ready certificates.cert-manager.io selfsigned-ca --timeout=${TIMEOUT}s
 
 # Create Cert-Manager Production (Cloudflare) Issuer
 


### PR DESCRIPTION
Tested new code, confirmed working.

Wait for certificate command was using the 'secret name':'tls-selfsigned-ca', when it needed to be looking for the 'name':'selfsigned-ca'.